### PR TITLE
Align map rendering to background image

### DIFF
--- a/components/MapView.tsx
+++ b/components/MapView.tsx
@@ -754,6 +754,7 @@ const MapView: React.FC<MapViewProps> = ({ mapImageUrl, nodes, edges, units, fac
             const img = new Image();
             img.src = mapImageUrl;
             img.onload = () => setMapImage(img);
+            img.onerror = () => setMapImage(null);
         } else {
             setMapImage(null);
         }
@@ -761,7 +762,7 @@ const MapView: React.FC<MapViewProps> = ({ mapImageUrl, nodes, edges, units, fac
     
     useEffect(() => {
         const canvas = canvasRef.current;
-        if (!canvas || !mapImage || nodes.length === 0) return;
+        if (!canvas || nodes.length === 0) return;
 
         const setInitialCamera = () => {
             let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
@@ -797,7 +798,7 @@ const MapView: React.FC<MapViewProps> = ({ mapImageUrl, nodes, edges, units, fac
         resizeObserver.observe(canvas);
 
         return () => resizeObserver.disconnect();
-    }, [mapImage, nodes]);
+    }, [nodes, mapImageUrl]);
     
     useEffect(() => {
         const dyingUnits = unitsToRender.filter(u => u.isDying && !prevUnitsRef.current.find(pu => pu.id === u.id && pu.isDying));
@@ -955,7 +956,7 @@ const MapView: React.FC<MapViewProps> = ({ mapImageUrl, nodes, edges, units, fac
     
     useEffect(() => {
         const canvas = canvasRef.current;
-        if (!canvas || !mapImage) return;
+        if (!canvas) return;
 
         const ctx = canvas.getContext('2d');
         if (!ctx) return;
@@ -989,8 +990,10 @@ const MapView: React.FC<MapViewProps> = ({ mapImageUrl, nodes, edges, units, fac
             ctx.translate(canvas.width / 2, canvas.height / 2);
             ctx.scale(cameraRef.current.zoom, cameraRef.current.zoom);
             ctx.translate(-cameraRef.current.centerX, -cameraRef.current.centerY);
-            
-            ctx.drawImage(mapImage, 0, 0, mapImage.naturalWidth, mapImage.naturalHeight);
+
+            if (mapImage) {
+                ctx.drawImage(mapImage, 0, 0);
+            }
 
             // --- Faction Territory Rendering (OPTIMIZED) ---
             if (mapFilters.factionControl.length > 0) {

--- a/components/SetupScreen.tsx
+++ b/components/SetupScreen.tsx
@@ -3,7 +3,7 @@ import { useGameDispatch, useGameState } from '../engine/hooks/useGameState';
 import { GameStateActionType, Faction, FactionName, Team } from '../types';
 import { loadStartPositions } from '../data/loaders';
 import { FactionIcon } from './Icons';
-import { CONFIG } from '../constants';
+import { CONFIG, MAP_IMAGE_URL } from '../constants';
 
 const allPossibleFactionsRaw = loadStartPositions();
 
@@ -58,8 +58,9 @@ const SetupScreen = () => {
     };
 
     const handleStartGame = () => {
-        if (customMapUrl) {
-            dispatch({ type: GameStateActionType.FINISH_SETUP, payload: { mapImageUrl: customMapUrl } });
+        const mapUrl = customMapUrl ?? MAP_IMAGE_URL;
+        if (mapUrl) {
+            dispatch({ type: GameStateActionType.FINISH_SETUP, payload: { mapImageUrl: mapUrl } });
         }
     };
 
@@ -67,7 +68,8 @@ const SetupScreen = () => {
     const schattenFactions = selectedFactions.filter(f => f.team === Team.Schatten);
     const lichtAp = lichtFactions.length > 0 ? Math.floor(CONFIG.TEAM_AP_POOL / lichtFactions.length) : 0;
     const schattenAp = schattenFactions.length > 0 ? Math.floor(CONFIG.TEAM_AP_POOL / schattenFactions.length) : 0;
-    const canStart = lichtFactions.length > 0 && schattenFactions.length > 0 && !!customMapUrl;
+    const mapPreviewUrl = customMapUrl ?? MAP_IMAGE_URL;
+    const canStart = lichtFactions.length > 0 && schattenFactions.length > 0 && !!mapPreviewUrl;
 
     return (
         <div className="flex items-center justify-center min-h-screen p-4 bg-[var(--color-bg)]">
@@ -134,8 +136,8 @@ const SetupScreen = () => {
                     <h2 className="text-2xl font-bold mb-4 text-center">Karte</h2>
                     <div className="p-4 bg-gray-900/50 rounded-lg flex flex-col items-center">
                         <div className="w-full max-w-md h-48 flex items-center justify-center bg-black/20 rounded-md border-2 border-gray-700 mb-4">
-                            {customMapUrl ? (
-                                <img src={customMapUrl} alt="Karten-Vorschau" className="w-full h-full object-contain rounded-md" />
+                            {mapPreviewUrl ? (
+                                <img src={mapPreviewUrl} alt="Karten-Vorschau" className="w-full h-full object-contain rounded-md" />
                             ) : (
                                 <p className="text-gray-400">Bitte lade ein Kartenbild hoch.</p>
                             )}
@@ -151,7 +153,11 @@ const SetupScreen = () => {
                                 </button>
                             )}
                         </div>
-                        <p className="text-xs text-gray-400 mt-2">Das hochgeladene Bild wird als Hintergrundkarte verwendet.</p>
+                        <p className="text-xs text-gray-400 mt-2 text-center">
+                            {customMapUrl
+                                ? 'Das hochgeladene Bild wird als Hintergrundkarte verwendet.'
+                                : 'Die Standardkarte wird verwendet. Du kannst optional eine eigene Karte hochladen.'}
+                        </p>
                     </div>
                 </div>
 
@@ -178,7 +184,7 @@ const SetupScreen = () => {
                     >
                         Match Starten
                     </button>
-                    {!canStart && <p className="text-xs text-gray-400 mt-2">Wähle mindestens eine Fraktion für jedes Team und lade eine Karte hoch.</p>}
+                    {!canStart && <p className="text-xs text-gray-400 mt-2">Wähle mindestens eine Fraktion für jedes Team.</p>}
                 </div>
             </div>
         </div>

--- a/constants.ts
+++ b/constants.ts
@@ -1,8 +1,9 @@
 import { FactionName } from './types';
 
-export const MAP_IMAGE_URL = ''; // Replace with your map image
-export const MAP_WIDTH = 1419;
-export const MAP_HEIGHT = 1064;
+// Provide a 928x1120 PNG at public/map-background.png or adjust the path to match your asset.
+export const MAP_IMAGE_URL = '/map-background.png';
+export const MAP_WIDTH = 928;
+export const MAP_HEIGHT = 1120;
 
 export const NODE_RADIUS = 8;
 export const UNIT_ICON_SIZE = 24;

--- a/data/loaders.ts
+++ b/data/loaders.ts
@@ -2,7 +2,7 @@
 
 
 import { NodeData, EdgeData, UnitTemplate, FactionName, TerrainType, UnitStats, Team, Card, CardDuration, Ability, FactionResearchTree, ResearchNode, ResearchCategory, ResearchEffect, ResearchUnlockCondition, ResearchUnlockConditionType, ShopItem } from '../types';
-import { CONFIG } from '../constants';
+import { CONFIG, MAP_WIDTH, MAP_HEIGHT } from '../constants';
 import { RAW_CARDS_DATA } from './embeddedData';
 import { RAW_NODES_DATA } from './nodes';
 import { RAW_EDGES_DATA } from './edges';
@@ -43,11 +43,31 @@ export const loadNodes = (): NodeData[] => {
         const parts = line.split(',');
         const id = parseInt(parts[0], 10);
         const terrainString = parts[7] as keyof typeof TerrainType;
-        
+
+        const rawX = parseFloat(parts[1]);
+        const rawY = parseFloat(parts[2]);
+        const normX = parseFloat(parts[3]);
+        const normY = parseFloat(parts[4]);
+        const sourceWidth = parseFloat(parts[5]);
+        const sourceHeight = parseFloat(parts[6]);
+
+        const hasNormalized = Number.isFinite(normX) && Number.isFinite(normY);
+        const hasSourceDimensions = Number.isFinite(sourceWidth) && Number.isFinite(sourceHeight) && sourceWidth > 0 && sourceHeight > 0;
+
+        const fallbackX = Number.isFinite(rawX) && hasSourceDimensions
+            ? (rawX / sourceWidth) * MAP_WIDTH
+            : rawX;
+        const fallbackY = Number.isFinite(rawY) && hasSourceDimensions
+            ? (rawY / sourceHeight) * MAP_HEIGHT
+            : rawY;
+
+        const scaledX = hasNormalized ? normX * MAP_WIDTH : fallbackX;
+        const scaledY = hasNormalized ? normY * MAP_HEIGHT : fallbackY;
+
         const node: NodeData = {
             id,
-            x: parseFloat(parts[1]),
-            y: parseFloat(parts[2]),
+            x: scaledX,
+            y: scaledY,
             terrain: TerrainType[terrainString] || TerrainType.Default,
             area: parts[8],
         };


### PR DESCRIPTION
## Summary
- scale node coordinates to the configured map dimensions so the PNG background sits at the correct origin
- allow the map canvas to render even when the background image fails to load and reset the camera when the image changes
- document the expected background asset path/dimensions and remove the checked-in binary placeholder

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d1a04f08b4832cb232e958838a68ba